### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/src/main/java/edu/jiangxin/searchengine/crawler/Crawler.java
+++ b/src/main/java/edu/jiangxin/searchengine/crawler/Crawler.java
@@ -70,7 +70,7 @@ public class Crawler implements Runnable {
 	 */
 	private static Set<String> extracLinks(final String url, final LinkFilter filter) {
 
-		Set<String> links = new HashSet<String>();
+		Set<String> links = new HashSet<>();
 		try {
 			Parser parser = new Parser(url);
 			// parser.setEncoding("utf8");

--- a/src/main/java/edu/jiangxin/searchengine/crawler/LinkQueue.java
+++ b/src/main/java/edu/jiangxin/searchengine/crawler/LinkQueue.java
@@ -22,10 +22,10 @@ public final class LinkQueue {
 	private static Condition isEmpty = lock.newCondition();
 
 	/** 已访问的 url 集合，之所以设为Set，是要保证其所包含的元素不重复. */
-	private static Set<String> visitedUrl = new HashSet<String>();
+	private static Set<String> visitedUrl = new HashSet<>();
 
 	/** 待访问的 url 集合. */
-	private static Queue<String> unVisitedUrl = new PriorityQueue<String>();
+	private static Queue<String> unVisitedUrl = new PriorityQueue<>();
 
 	/**
 	 *

--- a/src/main/java/edu/jiangxin/searchengine/createindex/CreateIndex.java
+++ b/src/main/java/edu/jiangxin/searchengine/createindex/CreateIndex.java
@@ -32,7 +32,7 @@ public class CreateIndex {
 	 * @throws IOException IOException
 	 */
 	public CreateIndex() throws IOException {
-		HashMap<String, String> hashResult = new HashMap<String, String>();
+		HashMap<String, String> hashResult = new HashMap<>();
 		File dirFile = new File("target/wordDoc");
 		File[] fileList = dirFile.listFiles();
 
@@ -42,7 +42,7 @@ public class CreateIndex {
 			for (int i = 0; i < fileList.length; i++) {
 				String fileName = fileList[i].getName();
 				System.out.println("\t现在正在对文件" + fileName + "进行分析");
-				HashMap<String, Integer> hashMap = new HashMap<String, Integer>();
+				HashMap<String, Integer> hashMap = new HashMap<>();
 				String content = FileUtils.readFileToString(new File("target/wordDoc/" + fileName), "UTF-8");
 				String[] wordArray = content.split(" ");
 				for (int j = 0; j < wordArray.length; j++) {

--- a/src/main/java/edu/jiangxin/searchengine/search/MyEngine.java
+++ b/src/main/java/edu/jiangxin/searchengine/search/MyEngine.java
@@ -25,7 +25,7 @@ public class MyEngine {
 	private String indexFile; // the index file
 
 	/**  */
-	private Vector<String> vecKey = new Vector<String>();
+	private Vector<String> vecKey = new Vector<>();
 
 	/**  */
 	private HashMap<String, String> hashWord = null;
@@ -55,7 +55,7 @@ public class MyEngine {
 	public MyEngine(final String indexFile) {
 		this.indexFile = indexFile; // 索引文件
 		long begin = System.currentTimeMillis();
-		hashWord = new HashMap<String, String>();
+		hashWord = new HashMap<>();
 		try {
 			String line = null;
 			File file = new File(indexFile);
@@ -90,9 +90,9 @@ public class MyEngine {
 			vecKey.add(keyBefore);
 			vecKey.add(keyAfter);
 			System.out.println("keyBefore is:" + keyBefore + "keyAfter is:" + keyAfter);
-			ArrayList<ResultModel> modList = new ArrayList<ResultModel>();
-			ArrayList<ResultModel> modListBefore = new ArrayList<ResultModel>();
-			ArrayList<ResultModel> modListAfter = new ArrayList<ResultModel>();
+			ArrayList<ResultModel> modList = new ArrayList<>();
+			ArrayList<ResultModel> modListBefore = new ArrayList<>();
+			ArrayList<ResultModel> modListAfter = new ArrayList<>();
 			if (this.hashWord.size() > 0) {
 				long begin = System.currentTimeMillis();
 				ResultModel[] modArray = null;
@@ -144,9 +144,9 @@ public class MyEngine {
 			vecKey.add(keyBefore);
 			vecKey.add(keyAfter);
 			System.out.println("keyBefore is:" + keyBefore + "keyAfter is:" + keyAfter);
-			ArrayList<ResultModel> modList = new ArrayList<ResultModel>();
-			ArrayList<ResultModel> modListBefore = new ArrayList<ResultModel>();
-			ArrayList<ResultModel> modListAfter = new ArrayList<ResultModel>();
+			ArrayList<ResultModel> modList = new ArrayList<>();
+			ArrayList<ResultModel> modListBefore = new ArrayList<>();
+			ArrayList<ResultModel> modListAfter = new ArrayList<>();
 			if (this.hashWord.size() > 0) {
 				long begin = System.currentTimeMillis();
 				ResultModel[] modArray = null;
@@ -194,7 +194,7 @@ public class MyEngine {
 			return modList;
 		}
 
-		ArrayList<ResultModel> modList = new ArrayList<ResultModel>();
+		ArrayList<ResultModel> modList = new ArrayList<>();
 		if (this.hashWord.size() > 0) {
 			long begin = System.currentTimeMillis();
 			ResultModel[] modArray = null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.
